### PR TITLE
Add devcontainer template

### DIFF
--- a/.devcontainer/Dockerfile.example
+++ b/.devcontainer/Dockerfile.example
@@ -1,0 +1,21 @@
+FROM python:3.12.3-slim-bookworm
+
+LABEL maintainer="info@joepverhaeg.nl"
+LABEL version="0.2"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    openssh-client \
+    lua5.4 \
+    git \
+    gcc \
+    build-essential && \
+    apt-get clean
+
+RUN git clone https://github.com/jangabrielsson/fibemu.git /fibemu-temp && \
+    pip install -r /fibemu-temp/requirements.txt && \
+    rm -fr /fibemu-temp
+
+WORKDIR /workspaces/fibemu
+
+CMD ["/bin/ash"]

--- a/.devcontainer/devcontainer.json.example
+++ b/.devcontainer/devcontainer.json.example
@@ -1,21 +1,16 @@
-FROM python:3.12.3-slim-bookworm
-
-LABEL maintainer="info@joepverhaeg.nl"
-LABEL version="0.2"
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash \
-    openssh-client \
-    lua5.4 \
-    git \
-    gcc \
-    build-essential && \
-    apt-get clean
-
-RUN git clone https://github.com/jangabrielsson/fibemu.git /fibemu-temp && \
-    pip install -r /fibemu-temp/requirements.txt && \
-    rm -fr /fibemu-temp
-
-WORKDIR /workspaces/fibemu
-
-CMD ["/bin/ash"]
+{
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "tomblind.local-lua-debugger-vscode",
+                "sumneko.lua"
+            ]
+        }
+    },
+    "forwardPorts": [
+        5004
+    ]
+}

--- a/.devcontainer/devcontainer.json.example
+++ b/.devcontainer/devcontainer.json.example
@@ -1,0 +1,21 @@
+FROM python:3.12.3-slim-bookworm
+
+LABEL maintainer="info@joepverhaeg.nl"
+LABEL version="0.2"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    openssh-client \
+    lua5.4 \
+    git \
+    gcc \
+    build-essential && \
+    apt-get clean
+
+RUN git clone https://github.com/jangabrielsson/fibemu.git /fibemu-temp && \
+    pip install -r /fibemu-temp/requirements.txt && \
+    rm -fr /fibemu-temp
+
+WORKDIR /workspaces/fibemu
+
+CMD ["/bin/ash"]

--- a/.devcontainer/resources/settings.json
+++ b/.devcontainer/resources/settings.json
@@ -1,0 +1,59 @@
+{
+    "json.validate.enable": false, // disable json validation, problem currently
+    "Lua.diagnostics.globals": [
+        "QuickApp",
+        "fibaro",
+        "api",
+        "net",
+        "json",
+        "___id",
+        "setTimeout",
+        "clearTimeout",
+        "setInterval",
+        "clearInterval",
+        "QuickAppChild",
+        "QuickAppBase",
+        "plugin",
+        "class",
+        "__fibaroSleep",
+        "__fibaro_get_global_variable",
+        "__fibaro_get_device",
+        "__fibaro_get_devices",
+        "__fibaro_get_room",
+        "__fibaro_get_scene",
+        "__fibaro_get_device_property",
+        "__fibaro_get_breached_partitions",
+        "__fibaro_add_debug_message",
+        "quickApp",
+        "__TAG",
+        "__assert_type",
+        "__fibaro_get_partition",
+        "hub",
+        "__print",
+        "__setTimeout",
+        "__clearTimeout",
+        "__fibaroUseAsyncHandler",
+        "QuickerAppChild",
+        "MyChild",
+        "UDPServer",
+        "QwikAppChild",
+        "sourceTrigger",
+        "RefreshStateSubscriber",
+        "_sceneId"
+    ],
+    "Lua.diagnostics.disable": [
+        "duplicate-set-field",
+        "param-type-mismatch"
+    ],
+    "Lua.editor.defaultFormatter": "JohnnyMorganz.stylua",
+    "Lua.workspace.library": [
+        "/workspaces/fibemu/.vscode/emufiles/lspaddon/library"
+    ],
+    "Lua.hint.enable": true,
+    "Lua.workspace.checkThirdParty": true,
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.autopep8"
+    },
+    "fibpython": "/usr/local/bin/python",
+    "python.formatting.provider": "none"
+}


### PR DESCRIPTION
Add a devcontainer setup. Renamed the files to `.template` to make activation a manual action.

Use the `settings.json` from the `.devcontainer/resources` folder to set the correct Python path and link to the language server files in the project.